### PR TITLE
correct names for onomy devnet and testnet

### DIFF
--- a/devnet.env
+++ b/devnet.env
@@ -1,7 +1,7 @@
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_ETHERSCAN_API_KEY=3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB
-REACT_APP_CHAIN_ID=ochain-devnet
+REACT_APP_CHAIN_ID=onomy
 REACT_APP_CHAIN_NAME=Onomy Devnet
 REACT_APP_ONOMY_RPC_URL=https://rpc-devnet.onomy.online
 REACT_APP_ONOMY_REST_URL=https://rest-devnet.onomy.online

--- a/devnet.env
+++ b/devnet.env
@@ -1,7 +1,7 @@
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_ETHERSCAN_API_KEY=3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB
-REACT_APP_CHAIN_ID=onomy
+REACT_APP_CHAIN_ID=onomy-devnet-2
 REACT_APP_CHAIN_NAME=Onomy Devnet
 REACT_APP_ONOMY_RPC_URL=https://rpc-devnet.onomy.online
 REACT_APP_ONOMY_REST_URL=https://rest-devnet.onomy.online

--- a/src/constants/env.js
+++ b/src/constants/env.js
@@ -1,7 +1,7 @@
 export const {
   REACT_APP_GRAPHQL_ENDPOINT = 'https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph',
   REACT_APP_ETHERSCAN_API_KEY = '3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB',
-  REACT_APP_CHAIN_ID = 'onomy',
+  REACT_APP_CHAIN_ID = 'onomy-devnet-2',
   REACT_APP_CHAIN_NAME = 'Onomy Devnet',
   REACT_APP_ONOMY_RPC_URL = 'https://rpc-devnet.onomy.online',
   REACT_APP_ONOMY_REST_URL = 'https://rest-devnet.onomy.online',

--- a/src/constants/env.js
+++ b/src/constants/env.js
@@ -1,7 +1,7 @@
 export const {
   REACT_APP_GRAPHQL_ENDPOINT = 'https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph',
   REACT_APP_ETHERSCAN_API_KEY = '3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB',
-  REACT_APP_CHAIN_ID = 'ochain-devnet',
+  REACT_APP_CHAIN_ID = 'onomy',
   REACT_APP_CHAIN_NAME = 'Onomy Devnet',
   REACT_APP_ONOMY_RPC_URL = 'https://rpc-devnet.onomy.online',
   REACT_APP_ONOMY_REST_URL = 'https://rest-devnet.onomy.online',

--- a/src/context/AutoLogin.js
+++ b/src/context/AutoLogin.js
@@ -38,11 +38,11 @@ export function AutoLogin({ children }) {
 
   /**
     const connectKeplr = async () => {
-      const chainId = "ochain-testnet";
+      const chainId = "onomy-testnet";
       if(window.keplr) {
         await window.keplr.experimentalSuggestChain({
           // Chain-id of the Cosmos SDK chain.
-          chainId: "ochain-testnet",
+          chainId: "onomy-testnet",
           // The name of the chain to be displayed to the user.
           chainName: "Onomy",
           // RPC endpoint of the chain.

--- a/testnet.env
+++ b/testnet.env
@@ -1,7 +1,7 @@
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_ETHERSCAN_API_KEY=3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB
-REACT_APP_CHAIN_ID=onomy-testnet
+REACT_APP_CHAIN_ID=onomy-testnet-2
 REACT_APP_CHAIN_NAME=Onomy Testnet
 REACT_APP_ONOMY_RPC_URL=https://rpc-testnet.onomy.online
 REACT_APP_ONOMY_REST_URL=https://rest-testnet.onomy.online

--- a/testnet.env
+++ b/testnet.env
@@ -1,7 +1,7 @@
 REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_REACT_APP_GRAPHQL_ENDPOINT=https://api.thegraph.com/subgraphs/name/onomyprotocol/ograph
 REACT_APP_ETHERSCAN_API_KEY=3CVJBSFD6KVNBTNFCBN2T2QHRVYP1K81YB
-REACT_APP_CHAIN_ID=ochain-testnet
+REACT_APP_CHAIN_ID=onomy-testnet
 REACT_APP_CHAIN_NAME=Onomy Testnet
 REACT_APP_ONOMY_RPC_URL=https://rpc-testnet.onomy.online
 REACT_APP_ONOMY_REST_URL=https://rest-testnet.onomy.online


### PR DESCRIPTION
Now the Kepler can't transfer tokens because of the worn chan names. This update include correcnt names of the devnet -> "onomy" and testnet -> "onomy-testnet" 